### PR TITLE
build: v1.37.0-alpha release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "kwctl"
-version = "1.36.0"
+version = "1.37.0-alpha"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.36.0"
+version = "1.37.0-alpha"
 dependencies = [
  "anyhow",
  "axum",

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 6.1.0
 # This is the version of Kubewarden stack
-appVersion: v1.37.0-alpha.1
+appVersion: v1.37.0-alpha
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.0-alpha.1
+version: 6.1.0
 # This is the version of Kubewarden stack
 appVersion: v1.37.0-alpha.1
 annotations:

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -1,0 +1,550 @@
+[![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)
+[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
+[![Artifact HUB](https://img.shields.io/badge/ArtifactHub-Helm_Charts-blue?style=flat&logo=artifacthub&link=https%3A%2F%2Fartifacthub.io%2Fpackages%2Fsearch%3Frepo%3Dkubewarden%26kind%3D0%26verified_publisher%3Dtrue%26official%3Dtrue%26cncf%3Dtrue%26sort%3Drelevance%26page%3D1)](https://artifacthub.io/packages/search?repo=kubewarden&kind=0&verified_publisher=true&official=true&cncf=true&sort=relevance&page=1)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6502/badge)](https://www.bestpractices.dev/projects/6502)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fadm-controller.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fadm-controller?ref=badge_shield&issueType=license)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubewarden/adm-controller/badge)](https://scorecard.dev/viewer/?uri=github.com/kubewarden/adm-controller)
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/kubewarden/badge)](https://clomonitor.io/projects/cncf/kubewarden)
+
+Kubewarden is a Kubernetes Dynamic Admission Controller that uses policies written
+in WebAssembly.
+
+For more information refer to the [official Kubewarden website](https://kubewarden.io/).
+
+# Kubewarden Admission Controller - Monorepo
+
+This repository is a monorepo containing the source code for all the different
+components of the Kubewarden Admission Controller:
+
+- **adm-controller**: A Kubernetes controller that allows you to dynamically register Kubewarden admission policies and reconcile them with the Kubernetes webhooks of the cluster where it's deployed
+- **policy-server**: The runtime component that evaluates admission policies written in WebAssembly
+- **audit-scanner**: A component that scans existing resources in the cluster against registered policies
+- **kwctl**: A CLI tool for testing and managing Kubewarden policies
+
+## Documentation
+
+The full and exhaustive documentation is available at [docs.kubewarden.io](https://docs.kubewarden.io).
+
+The [`docs/`](./docs) folder contains README files for each component:
+
+- [Controller](./docs/controller)
+- [Policy Server](./docs/policy-server)
+- [Audit Scanner](./docs/audit-scanner)
+- [kwctl](./docs/kwctl)
+- [CRDs](./docs/crds)
+
+## Installation
+
+The adm-controller can be deployed using a Helm chart. For instructions, see
+https://charts.kubewarden.io.
+
+Please refer to our [quickstart](https://docs.kubewarden.io/quick-start) for
+more details.
+
+> **Note:** This chart replaces the three separate charts that were used
+> previously: `kubewarden-crds`, `kubewarden-controller`, and
+> `kubewarden-defaults`.
+
+## Migration from three-chart setup
+
+If you are running the legacy three-chart setup (`kubewarden-crds`,
+`kubewarden-controller`, `kubewarden-defaults`), there are two ways to migrate to
+the new single helm chart. Users can use the migration script
+(`kubewarden-unified-adm-controller-chart-migration.sh`) to move to this chart
+without admission downtime. Or uninstall the old Helm charts and reinstall the
+new single Helm chart acknowledging that this procedure will cause down time in the
+policy evaluations.
+
+### Manual reinstallation
+
+This is the simplest migration path. But it will cause the policies to stop
+being evaluated during the process. In the procedure users must backup all the
+policies and policy servers, uninstall the previous Kubewarden stack and
+reinstall the new single Helm chart. Once the stack is installed again, the
+backup resources can be reapplied.
+
+The reinstallation can follow the below steps:
+
+1. Back your policies and policy servers:
+
+```sh
+FILTER='del(.items[].metadata.uid, .items[].metadata.resourceVersion, .items[].metadata.creationTimestamp, .items[].metadata.generation, .items[].metadata.managedFields, .items[].status)'
+
+kubectl get clusteradmissionpolicies -A -o yaml | yq "$FILTER" > clusteradmissionpolicies-backup.yaml
+kubectl get admissionpolicies -A -o yaml | yq "$FILTER" > admissionpolicies-backup.yaml
+kubectl get clusteradmissionpolicygroups -A -o yaml | yq "$FILTER" > clusteradmissionpolicygroups-backup.yaml
+kubectl get admissionpolicygroups -A -o yaml | yq "$FILTER" > admissionpolicygroups-backup.yaml
+kubectl get policyservers -A -o yaml | yq "$FILTER" > policyservers-backup.yaml
+```
+
+2. Uninstall old Helm charts:
+
+```sh
+helm uninstall kubewarden-defaults -n kubewarden
+helm uninstall kubewarden-controller -n kubewarden
+helm uninstall kubewarden-crds -n kubewarden
+```
+
+3. Install the unified Helm chart:
+
+```sh
+helm install kubewarden kubewarden/admission-controller -n kubewarden
+```
+
+It's important to note that the new single Helm chart also unified the values
+files. Thus, your previous values files should work still. Therefore, to have
+the same stack again you can merge all the values files used in the old 3 helm
+charts into one and use in the new Helm chart installation as well:
+
+```sh
+helm install kubewarden kubewarden/admission-controller -n kubewarden --values all-values.yaml
+```
+
+4. Restore policies and policy servers:
+
+```sh
+kubectl apply -f policyservers-backup.yaml
+kubectl apply -f clusteradmissionpolicies-backup.yaml
+kubectl apply -f admissionpolicies-backup.yaml
+kubectl apply -f clusteradmissionpolicygroups-backup.yaml
+kubectl apply -f admissionpolicygroups-backup.yaml
+```
+
+After the reconciliation loop run, the Kubewarden stack should be up and
+running as before.
+
+### Migration script
+
+The migration requires several Helm operations in a specific order:
+adding resource-preservation annotations to the stored release
+manifests, uninstalling the legacy releases without running cleanup
+hooks, then installing the unified chart so it adopts the existing
+resources. The ordering matters because annotations must be in the
+stored manifest (not just on live objects) for Helm to honor them,
+hooks must be skipped or they delete PolicyServers, and both the
+release name and the chart's `nameOverride` must match the legacy ones
+(see the "Chart rename / resource naming" caveat) or Kubernetes
+rejects the update due to immutable selectors. Getting any step wrong
+can delete resources or break admission, so the script handles it all
+and verifies each step.
+
+What survives the migration:
+
+- The five Kubewarden CRDs.
+- Your custom `PolicyServer` instances and policy CRs, along with
+  their `Validating`/`MutatingWebhookConfiguration` objects.
+- The `default` `PolicyServer` and recommended policy CRs (if
+  enabled). The unified chart's DefaultsApplier adopts them in
+  place. The `policy-server-default` Deployment is owned by the
+  `PolicyServer` CR through an owner reference, so as long as the
+  CR survives, the Deployment stays up and admission continues.
+- The `kubewarden-ca` Secret. Already-running policy-server pods
+  stay trusted by the new webhook CA bundles. No TLS rotation
+  happens.
+
+To facilitate the migration process the Kubewarden team provided a script that
+perform all the required operation to allow a migration to the unified Helm
+chart with no downtime. To be able to use the script users must be aware of the
+prerequisites listed below.
+
+If for some reason some of the prerequisites is not possible user should backup
+all the resources they currently have which is the policy servers and policies
+and reinstall them after the reinstallation of the stack. This means that the
+migration will cause down time in the policy evaluation.
+
+> [!WARNING]
+> The Kubewarden team test the migration path as much as possible. But it is
+> still recommended to backup policies and policy server definitions just in
+> case something unexpected happens. Therefore, it will be easier to restore to
+> the previous state if necessary.
+
+### Prerequisites
+
+- Helm v4+ (needed for Server-Side Apply and post-renderer plugins)
+- kubectl with access to your cluster
+- yq v4 (github.com/mikefarah/yq) for the post-renderer
+- jq for detecting installed chart versions
+- The three legacy releases must be installed in your cluster
+
+The script runs five phases:
+
+1. Preflight: checks that the required tools are available, connects
+   to the cluster, finds the three legacy releases, and warns if
+   they are not at the latest chart version.
+2. Annotation injection: creates a Helm 4 post-renderer plugin that
+   wraps `yq`, then runs `helm upgrade --reuse-values --post-renderer`
+   on each legacy release to write `helm.sh/resource-policy: keep`
+   into the stored release manifests.
+3. Legacy uninstall: runs `helm uninstall --no-hooks` in reverse
+   order. The `--no-hooks` flag skips the controller chart's
+   pre-delete hook, which would otherwise delete all PolicyServers.
+   Resources stay live in the cluster.
+4. Unified chart install: runs `helm install --take-ownership`.
+   Helm 4's Server-Side Apply adopts existing resources, updates
+   their ownership metadata, and removes the legacy keep annotations
+   from chart-rendered resources.
+5. Verification: checks that CRDs are owned by the new release,
+   RBAC resources were adopted in place (UIDs did not change), the
+   controller pod is running, and the DefaultsApplier has labeled
+   the default PolicyServer and recommended policies.
+
+### Running the migration
+
+```sh
+./kubewarden-unified-adm-controller-chart-migration.sh \
+  --unified-chart kubewarden/admission-controller
+```
+
+Using a local tarball:
+
+```sh
+./kubewarden-unified-adm-controller-chart-migration.sh \
+  --unified-chart ./admission-controller-6.0.0.tgz
+```
+
+Dry run (no changes applied):
+
+```sh
+./kubewarden-unified-adm-controller-chart-migration.sh \
+  --unified-chart kubewarden/admission-controller --dry-run
+```
+
+Interactive mode (pauses before each destructive step):
+
+```sh
+./kubewarden-unified-adm-controller-chart-migration.sh \
+  --unified-chart kubewarden/admission-controller --interactive
+```
+
+Passing custom values to the unified chart:
+
+```sh
+./kubewarden-unified-adm-controller-chart-migration.sh \
+  --unified-chart kubewarden/admission-controller \
+  --set "image.tag=v2.0.0" \
+  --values ./my-custom-values.yaml
+```
+
+#### Available flags
+
+| Flag                           | Description                                                      |
+| ------------------------------ | ---------------------------------------------------------------- |
+| `--unified-chart PATH_OR_NAME` | Required. Local tarball or Helm repo chart name                  |
+| `--namespace NS`               | Namespace of the Kubewarden installation (default: `kubewarden`) |
+| `--kube-context CTX`           | Kubernetes context to use (default: current context)             |
+| `--repo-name NAME`             | Helm repo name (default: `kubewarden`)                           |
+| `--repo-url URL`               | Helm repo URL (default: `https://charts.kubewarden.io`)          |
+| `--timeout DURATION`           | Timeout for Helm operations (default: `5m`)                      |
+| `--set KEY=VALUE`              | Set a value for the unified chart install (repeatable)           |
+| `--values FILE` / `-f FILE`    | Values file for the unified chart install (repeatable)           |
+| `--interactive`                | Pause for confirmation before destructive steps                  |
+| `--dry-run`                    | Show what would be done without making changes                   |
+| `--help`                       | Print usage information                                          |
+
+### Caveats
+
+**Release name.** The unified chart must be installed with the same
+release name as the legacy `kubewarden-controller` release (usually
+`kubewarden-controller`). Kubernetes Deployments have an immutable
+`spec.selector.matchLabels` that includes
+`app.kubernetes.io/instance: <release-name>`. If the name does not
+match, the install fails with an immutable-field error. The script
+detects the legacy release name automatically.
+
+**Chart rename / resource naming.** This chart is named
+`admission-controller`, so a fresh install names its resources after it
+(`app.kubernetes.io/name: admission-controller`, Deployment
+`<release>-admission-controller`). The legacy resources being adopted were
+created by the old `kubewarden-controller` chart and carry
+`app.kubernetes.io/name: kubewarden-controller` in the same immutable
+selector. The migration script builds a values file by concatenating
+`helm get values` from the three legacy releases (`kubewarden-crds`,
+`kubewarden-controller`, `kubewarden-defaults`) and writes a reconciled
+`nameOverride` into it (filled with `kubewarden-controller` only when
+you had not set it) so the chart reproduces the old names/labels and
+Server-Side Apply adopts the objects in place. Any `--set`/`--values`
+you pass to the script override the merged values. These values are
+stored in the release, so **future upgrades must keep them** — run
+`helm upgrade ... --reuse-values`, or pass the generated
+`kw-merged-values.yaml` with `--values`. Dropping `nameOverride`
+re-renders `admission-controller`-named selectors and fails on the immutable
+field. (A cluster migrated this way keeps `kubewarden-controller`
+resource names; a brand-new install uses `admission-controller`.)
+
+**Controller gap.** Between the legacy uninstall and the unified
+chart becoming ready, no controller is running. Existing webhook
+configurations are still served by the surviving policy-server pods,
+so admission for active policies keeps working. New policy CRs
+created during this window are not reconciled into webhooks until
+the new controller starts.
+
+**Legacy defaults not carried over.** The migration script uses
+`helm get values` (user-supplied overrides only, not `--all`) to build
+the merged values file. Settings that were only legacy chart
+_defaults_ (never explicitly set by you) are not carried over. If you
+relied on them, pass them with `--set` or `--values`. Notably, the
+unified chart defaults are `recommendedPolicies.enabled: false` and
+`recommendedPolicies.defaultPolicyMode: "monitor"` (the script no
+longer forces `enabled=true` / `protect`). If the legacy defaults chart
+enabled recommended policies by default and you never overrode that,
+pass `--set recommendedPolicies.enabled=true` and
+`--set recommendedPolicies.defaultPolicyMode=protect` to keep them.
+
+**Settings drift.** The DefaultsApplier rewrites each recommended
+policy's spec to match the values you pass to the unified chart. If
+you had changed `mode`, `settings`, or other fields on the
+recommended policies, pass those same values with `--set` or
+`--values` to preserve your configuration.
+
+**Renamed policies.** The unified chart's default policy names match
+the legacy defaults. If you renamed any through legacy values, pass
+the same `name` overrides with `--set` or `--values`. Otherwise the
+applier removes the old-named CRs after install.
+
+**Custom RBAC.** If you added extra permissions to
+`kubewarden-context-watcher` by hand, the unified chart overwrites
+them on install. Include those permissions in a values file or pass
+them with `--set "policyServer.permissions[0].apiGroup=..."`.
+
+## Configuration
+
+### Defaults
+
+The chart can deploy a default Policy Server and recommended policies:
+
+```yaml
+policyServer:
+  enabled: true
+  replicaCount: 1
+  # ... (see values.yaml for full options)
+
+recommendedPolicies:
+  enabled: false # disabled by default
+  defaultPolicyMode: "monitor"
+  allowPrivilegeEscalationPolicy:
+    # ... (see values.yaml)
+```
+
+These resources are owned and reconciled by the controller. Manual
+changes are reverted on the next reconciliation. Setting `enabled`
+to `false` removes all managed resources.
+
+### CRDs
+
+CRDs are installed with the `helm.sh/resource-policy: keep` annotation:
+
+- `helm upgrade` updates CRDs normally
+- `helm uninstall` does not delete CRDs, which prevents cascade-deletion of all PolicyServers and policies in the cluster
+
+#### Reinstalling under a different release name or namespace
+
+Because the CRDs are kept on uninstall, they survive with the Helm
+ownership metadata of the release that created them
+(`meta.helm.sh/release-name` and `meta.helm.sh/release-namespace`). Helm
+checks this metadata on the next install:
+
+- Same release name **and** namespace: Helm adopts the existing CRDs and
+  the install succeeds.
+- Different release name **or** namespace: Helm refuses to take over the
+  CRDs and the install fails with:
+
+  ```
+  Error: ... invalid ownership metadata; annotation
+  meta.helm.sh/release-name must equal "<new>": current value is "<old>"
+  ```
+
+This is expected: the CRDs still belong to the previous release. To adopt
+them into the new release, install with `--take-ownership` (Helm 3.18+ or
+Helm 4), which re-stamps the ownership metadata:
+
+```sh
+helm install <release> <chart> -n <namespace> --take-ownership
+```
+
+## Uninstall
+
+```sh
+helm uninstall kubewarden-controller -n kubewarden
+```
+
+This removes:
+
+- The controller Deployment
+- Managed defaults (resources labeled `kubewarden.io/managed-by=kubewarden-controller-defaults`)
+- ConfigMaps, Secrets, Services
+
+It does not remove:
+
+- CRDs (kept by `helm.sh/resource-policy: keep`)
+- User-managed PolicyServers and policies
+
+To remove CRDs after uninstall:
+
+```sh
+kubectl delete crd policyservers.policies.kubewarden.io
+kubectl delete crd clusteradmissionpolicies.policies.kubewarden.io
+kubectl delete crd admissionpolicies.policies.kubewarden.io
+kubectl delete crd clusteradmissionpolicygroups.policies.kubewarden.io
+kubectl delete crd admissionpolicygroups.policies.kubewarden.io
+```
+
+# Software bill of materials & provenance
+
+All Kubewarden components has its software bill of materials (SBOM) and build
+[Provenance](https://slsa.dev/spec/v1.0/provenance) information published every
+release. It follows the [SPDX](https://spdx.dev/) format and
+[SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema.
+Both of the files are generated by [Docker
+buildx](https://docs.docker.com/build/metadata/attestations/) during the build
+process and stored in the container registry together with the container image
+as well as upload in the release page.
+
+You can find them together with the signature and certificate used to sign it
+in the [release
+assets](https://github.com/kubewarden/adm-controller/releases), and
+attached to the image as JSON-encoded documents following the [in-toto SPDX
+predicate](https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md)
+format. You can obtain them with
+[`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
+or [`docker buildx imagetools
+inspect`](https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect).
+
+You can verify the container image with:
+
+```shell
+cosign verify-blob --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \
+    --certificate-identity="https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@<TAG TO VERIFY>" \
+    --bundle controller-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore \
+    controller-attestation-amd64-provenance.intoto.jsonl
+```
+
+To verify the attestation manifest and its layer signatures:
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \
+    --certificate-identity="https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@<TAG TO VERIFY>" \
+    ghcr.io/kubewarden/adm-controller/controller@sha256:1abc0944378d9f3ee2963123fe84d045248d320d76325f4c2d4eb201304d4c4e
+```
+
+> [!NOTE]
+> All the commands and file locations used in this section to validate the
+> controller components can be used to verify all the others Kubewarden
+> components as well.
+
+That sha256 hash is the digest of the attestation manifest or its layers.
+Therefore, you need to find this hash in the registry using the UI or tools
+like `crane`. For example, the following command will show you all the
+attestation manifests of the `latest` tag:
+
+```shell
+crane manifest  ghcr.io/kubewarden/adm-controller/controller:latest | jq '.manifests[] | select(.annotations["vnd.docker.reference.type"]=="attestation-manifest")'
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "digest": "sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8",
+  "size": 1655,
+  "annotations": {
+    "vnd.docker.reference.digest": "sha256:611d499ec9a26034463f09fa4af4efe2856086252d233b38e3fc31b0b982d369",
+    "vnd.docker.reference.type": "attestation-manifest"
+  },
+  "platform": {
+    "architecture": "unknown",
+    "os": "unknown"
+  }
+}
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "digest": "sha256:e0cd736c2241407114256e09a4cdeef55eb81dcd374c5785c4e5c9362a0088a2",
+  "size": 1655,
+  "annotations": {
+    "vnd.docker.reference.digest": "sha256:03e5db83a25ea2ac498cf81226ab8db8eb53a74a2c9102e4a1da922d5f68b70f",
+    "vnd.docker.reference.type": "attestation-manifest"
+  },
+  "platform": {
+    "architecture": "unknown",
+    "os": "unknown"
+  }
+}
+```
+
+Then you can use the `digest` field to verify the attestation manifest and its
+layers signatures.
+
+```shell
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \
+    --certificate-identity="https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@<TAG TO VERIFY>" \
+    ghcr.io/kubewarden/adm-controller/controller@sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8
+
+crane manifest  ghcr.io/kubewarden/adm-controller/controller@sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:eda788a0e94041a443eca7286a9ef7fce40aa2832263f7d76c597186f5887f6a",
+    "size": 463
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:563689cdee407ab514d057fe2f8f693189279e10bfe4f31f277e24dee00793ea",
+      "size": 94849,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:7ce0572628290373e17ba0bbb44a9ec3c94ba36034124931d322ca3fbfb768d9",
+      "size": 7363045,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:dacf511c5ec7fd87e8692bd08c3ced2c46f4da72e7271b82f1b3720d5b0a8877",
+      "size": 71331,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:594da3e8bd8c6ee2682b0db35857933f9558fd98ec092344a6c1e31398082f4d",
+      "size": 980,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:7738d8d506c6482aaaef1d22ed920468ffaf4975afd28f49bb50dba2c20bf2ca",
+      "size": 13838,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v0.2"
+      }
+    }
+  ]
+}
+
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \
+    --certificate-identity="https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@<TAG TO VERIFY>" \
+    ghcr.io/kubewarden/adm-controller/controller@sha256:594da3e8bd8c6ee2682b0db35857933f9558fd98ec092344a6c1e31398082f4d
+```
+
+Note that each attestation manifest (for each architecture) has its own layers.
+Each layer is a different SBOM SPDX or provenance file generated by Docker
+Buildx during the multi stage build process. You can also use `crane` to
+download the attestation file:
+
+```shell
+crane blob ghcr.io/kubewarden/adm-controller/controller@sha256:7738d8d506c6482aaaef1d22ed920468ffaf4975afd28f49bb50dba2c20bf2ca
+```
+
+## Security disclosure
+
+See [SECURITY.md](https://github.com/kubewarden/community/blob/main/SECURITY.md) on the kubewarden/community repo.
+
+# Changelog
+
+See [GitHub Releases content](https://github.com/kubewarden/adm-controller/releases).

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -256,7 +256,7 @@ image:
   # controller image to be used
   repository: "kubewarden/adm-controller/controller"
   # image tag
-  tag: v1.36.0
+  tag: v1.37.0-alpha
   pullPolicy: IfNotPresent
 preDeleteJob:
   image:

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -333,7 +333,7 @@ auditScanner:
     # The registry is defined in the common.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/adm-controller/audit-scanner"
-    tag: v1.36.0
+    tag: v1.37.0-alpha
     pullPolicy: IfNotPresent
   cronJob:
     schedule: "0 * * * *" # every 60 minutes

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -403,7 +403,6 @@ installPolicyReportCRDs: false # @schema deprecated
 # Set to false if they are already defined inside of the cluster
 installOpenReportsCRDs: true
 
-
 # Policy Server settings
 policyServer:
   enabled: true
@@ -414,7 +413,7 @@ policyServer:
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/adm-controller/policy-server"
-    tag: v1.36.0
+    tag: v1.37.0-alpha
   serviceAccountName: policy-server
   # Configmap containing a Sigstore verification configuration under a key
   # named `verification-config`. Must be on the same ns as the PolicyServer.
@@ -462,7 +461,7 @@ policyServer:
   #  - "source1"
   #  - "source2"
   # @schema item: string
-  insecureSources: [] 
+  insecureSources: []
   # sourceAuthorities is a list of the URIs and their PEM encoded certificates
   # used to authenticate them
   #
@@ -479,7 +478,7 @@ policyServer:
   #     certs:
   #       - "cert4"
   # @schema type:[array]
-  sourceAuthorities: [] 
+  sourceAuthorities: []
   # namespacedPoliciesCapabilities lists host capability API calls allowed
   # for namespaced policies running on this PolicyServer.
   # Supported patterns: [] (none), "*" (all), "category/*",
@@ -531,7 +530,7 @@ recommendedPolicies:
   # Additional namespaces that recommended policies will not apply to:
   skipAdditionalNamespaces: []
   defaultPolicyMode: "monitor"
-  
+
   allowPrivilegeEscalationPolicy:
     module:
       repository: "kubewarden/policies/allow-privilege-escalation-psp"
@@ -539,7 +538,7 @@ recommendedPolicies:
     name: "no-privilege-escalation"
     settings:
       allowPrivilegeEscalation: false
-      
+
   hostNamespacePolicy:
     module:
       repository: "kubewarden/policies/host-namespaces-psp"
@@ -550,7 +549,7 @@ recommendedPolicies:
       allow_host_network: false
       allow_host_pid: false
       allow_host_ports: []
-      
+
   podPrivilegedPolicy:
     module:
       repository: "kubewarden/policies/pod-privileged"
@@ -559,7 +558,7 @@ recommendedPolicies:
     settings:
       skip_init_containers: false
       skip_ephemeral_containers: false
-      
+
   userGroupPolicy:
     module:
       repository: "kubewarden/policies/user-group-psp"
@@ -573,7 +572,7 @@ recommendedPolicies:
       supplemental_groups:
         rule: "RunAsAny"
       validate_container_image_configuration: false
-      
+
   hostPathsPolicy:
     module:
       repository: "kubewarden/policies/hostpaths-psp"
@@ -583,7 +582,7 @@ recommendedPolicies:
       allowedHostPaths:
         - pathPrefix: "/tmp"
           readOnly: true
-          
+
   capabilitiesPolicy:
     module:
       repository: "kubewarden/policies/capabilities-psp"

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -13,11 +13,11 @@ metadata:
 spec:
   images:
     - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.36.0
-      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.36.0
+      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
     - name: ghcr.io/kubewarden/adm-controller/controller:v1.36.0
-      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.36.0
+      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
     - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
-      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.36.0
+      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
 ---
 # The policies are in a separated definition just to allow a better keyless validation
 # without the need to duplicate configuration

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -32,7 +32,7 @@ spec:
   images:
     - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
-    - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.9
+    - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.8
     - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.7
     - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.10
     - name: ghcr.io/kubewarden/policies/user-group-psp:v1.1.5

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -12,7 +12,7 @@ metadata:
     hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
 spec:
   images:
-    - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.36.0
+    - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.0-alpha
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
     - name: ghcr.io/kubewarden/adm-controller/controller:v1.36.0
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -16,7 +16,7 @@ spec:
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
     - name: ghcr.io/kubewarden/adm-controller/controller:v1.36.0
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
-    - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
+    - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.0-alpha
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
 ---
 # The policies are in a separated definition just to allow a better keyless validation

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -14,7 +14,7 @@ spec:
   images:
     - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.0-alpha
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
-    - name: ghcr.io/kubewarden/adm-controller/controller:v1.36.0
+    - name: ghcr.io/kubewarden/adm-controller/controller:v1.37.0-alpha
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha
     - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.0-alpha
       certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.0-alpha

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -34,7 +34,7 @@ spec:
     - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.9
     - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.7
-    - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.11
+    - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.10
     - name: ghcr.io/kubewarden/policies/user-group-psp:v1.1.5
 ---
 # The policy reporter and kuberlr images are defined in the dedicated manifest section because

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   images:
     - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.11
-    - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.11
+    - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.9
     - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.8
     - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.11

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -33,7 +33,7 @@ spec:
     - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.11
     - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.9
-    - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.8
+    - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.7
     - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.11
     - name: ghcr.io/kubewarden/policies/user-group-psp:v1.1.5
 ---

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -58,7 +58,7 @@ spec:
   charts:
     - name: admission-controller
       repoURL: https://charts.kubewarden.io
-      version: 6.0.0-alpha.1
+      version: 6.1.0
     - name: policy-reporter
       version: 3.7.4
       repoURL: https://kyverno.github.io/policy-reporter

--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -30,7 +30,7 @@ metadata:
     hauler.dev/certificate-identity-regexp: https://github.com/kubewarden/policies/.github/workflows/release.yml@refs/tags/.*
 spec:
   images:
-    - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.11
+    - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
     - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.9
     - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.7

--- a/crates/kwctl/Cargo.toml
+++ b/crates/kwctl/Cargo.toml
@@ -3,7 +3,7 @@ authors     = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io
 description = "Tool to manage Kubewarden policies"
 edition     = "2024"
 name        = "kwctl"
-version     = "1.36.0"
+version     = "1.37.0-alpha"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/policy-server/Cargo.toml
+++ b/crates/policy-server/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2024"
 name = "policy-server"
-version = "1.36.0"
+version = "1.37.0-alpha"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION


Automatic bump to `v1.37.0-alpha` release.

Changes since last released tag: (if no tag, since HEAD^): https://github.com/jvanz/adm-controller/compare/v2.0.0...updatecli_main_release_pr

> [!IMPORTANT]
> REMEMBER USING SQUASH MERGE FOR THIS PR


---



<Actions>
    <action id="15c34d4c0e5f44cca77fb247f80301343193845514d73b05f07bdf6a2d636943">
        <h3>Update admission-controller chart version</h3>
        <details id="1246f74dbc63fd95254017856a46cf168101d0c6b79f5e48177890d98eebb1d9">
            <summary>Update Helm chart admission-controller version</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.version&#34; updated from &#34;6.0.0-alpha.1&#34; to &#34;6.1.0&#34;, in file &#34;charts/admission-controller/Chart.yaml&#34;</p>
        </details>
        <details id="1489ff8c0ade01594a6cd016b88257611bac67d813e2f61a10ce9f4d28badc66">
            <summary>Update Cargo.toml, Cargo.lock with new version</summary>
            <p>ran shell command &#34;cargo set-version --package policy-server --package kwctl 1.37.0-alpha&#34;</p>
        </details>
        <details id="631c286b2b898a20dc2ccf4820f8b67a87fb2bb75167a693b5a841839d921169">
            <summary>Update Helm chart admission-controller README</summary>
            <p>1 file(s) updated with &#34;[![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)\n[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)\n[![Artifact HUB](https://img.shields.io/badge/ArtifactHub-Helm_Charts-blue?style=flat&amp;logo=artifacthub&amp;link=https%3A%2F%2Fartifacthub.io%2Fpackages%2Fsearch%3Frepo%3Dkubewarden%26kind%3D0%26verified_publisher%3Dtrue%26official%3Dtrue%26cncf%3Dtrue%26sort%3Drelevance%26page%3D1)](https://artifacthub.io/packages/search?repo=kubewarden&amp;kind=0&amp;verified_publisher=true&amp;official=true&amp;cncf=true&amp;sort=relevance&amp;page=1)\n[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6502/badge)](https://www.bestpractices.dev/projects/6502)\n[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fadm-controller.svg?type=shield&amp;issueType=license)](https://app.fossa.com/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fadm-controller?ref=badge_shield&amp;issueType=license)\n[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubewarden/adm-controller/badge)](https://scorecard.dev/viewer/?uri=github.com/kubewarden/adm-controller)\n[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/kubewarden/badge)](https://clomonitor.io/projects/cncf/kubewarden)\n\nKubewarden is a Kubernetes Dynamic Admission Controller that uses policies written\nin WebAssembly.\n\nFor more information refer to the [official Kubewarden website](https://kubewarden.io/).\n\n# Kubewarden Admission Controller - Monorepo\n\nThis repository is a monorepo containing the source code for all the different\ncomponents of the Kubewarden Admission Controller:\n\n- **adm-controller**: A Kubernetes controller that allows you to dynamically register Kubewarden admission policies and reconcile them with the Kubernetes webhooks of the cluster where it&#39;s deployed\n- **policy-server**: The runtime component that evaluates admission policies written in WebAssembly\n- **audit-scanner**: A component that scans existing resources in the cluster against registered policies\n- **kwctl**: A CLI tool for testing and managing Kubewarden policies\n\n## Documentation\n\nThe full and exhaustive documentation is available at [docs.kubewarden.io](https://docs.kubewarden.io).\n\nThe [`docs/`](./docs) folder contains README files for each component:\n\n- [Controller](./docs/controller)\n- [Policy Server](./docs/policy-server)\n- [Audit Scanner](./docs/audit-scanner)\n- [kwctl](./docs/kwctl)\n- [CRDs](./docs/crds)\n\n## Installation\n\nThe adm-controller can be deployed using a Helm chart. For instructions, see\nhttps://charts.kubewarden.io.\n\nPlease refer to our [quickstart](https://docs.kubewarden.io/quick-start) for\nmore details.\n\n&gt; **Note:** This chart replaces the three separate charts that were used\n&gt; previously: `kubewarden-crds`, `kubewarden-controller`, and\n&gt; `kubewarden-defaults`.\n\n## Migration from three-chart setup\n\nIf you are running the legacy three-chart setup (`kubewarden-crds`,\n`kubewarden-controller`, `kubewarden-defaults`), there are two ways to migrate to\nthe new single helm chart. Users can use the migration script\n(`kubewarden-unified-adm-controller-chart-migration.sh`) to move to this chart\nwithout admission downtime. Or uninstall the old Helm charts and reinstall the\nnew single Helm chart acknowledging that this procedure will cause down time in the\npolicy evaluations.\n\n### Manual reinstallation\n\nThis is the simplest migration path. But it will cause the policies to stop\nbeing evaluated during the process. In the procedure users must backup all the\npolicies and policy servers, uninstall the previous Kubewarden stack and\nreinstall the new single Helm chart. Once the stack is installed again, the\nbackup resources can be reapplied.\n\nThe reinstallation can follow the below steps:\n\n1. Back your policies and policy servers:\n\n```sh\nFILTER=&#39;del(.items[].metadata.uid, .items[].metadata.resourceVersion, .items[].metadata.creationTimestamp, .items[].metadata.generation, .items[].metadata.managedFields, .items[].status)&#39;\n\nkubectl get clusteradmissionpolicies -A -o yaml | yq \&#34;$FILTER\&#34; &gt; clusteradmissionpolicies-backup.yaml\nkubectl get admissionpolicies -A -o yaml | yq \&#34;$FILTER\&#34; &gt; admissionpolicies-backup.yaml\nkubectl get clusteradmissionpolicygroups -A -o yaml | yq \&#34;$FILTER\&#34; &gt; clusteradmissionpolicygroups-backup.yaml\nkubectl get admissionpolicygroups -A -o yaml | yq \&#34;$FILTER\&#34; &gt; admissionpolicygroups-backup.yaml\nkubectl get policyservers -A -o yaml | yq \&#34;$FILTER\&#34; &gt; policyservers-backup.yaml\n```\n\n2. Uninstall old Helm charts:\n\n```sh\nhelm uninstall kubewarden-defaults -n kubewarden\nhelm uninstall kubewarden-controller -n kubewarden\nhelm uninstall kubewarden-crds -n kubewarden\n```\n\n3. Install the unified Helm chart:\n\n```sh\nhelm install kubewarden kubewarden/admission-controller -n kubewarden\n```\n\nIt&#39;s important to note that the new single Helm chart also unified the values\nfiles. Thus, your previous values files should work still. Therefore, to have\nthe same stack again you can merge all the values files used in the old 3 helm\ncharts into one and use in the new Helm chart installation as well:\n\n```sh\nhelm install kubewarden kubewarden/admission-controller -n kubewarden --values all-values.yaml\n```\n\n4. Restore policies and policy servers:\n\n```sh\nkubectl apply -f policyservers-backup.yaml\nkubectl apply -f clusteradmissionpolicies-backup.yaml\nkubectl apply -f admissionpolicies-backup.yaml\nkubectl apply -f clusteradmissionpolicygroups-backup.yaml\nkubectl apply -f admissionpolicygroups-backup.yaml\n```\n\nAfter the reconciliation loop run, the Kubewarden stack should be up and\nrunning as before.\n\n### Migration script\n\nThe migration requires several Helm operations in a specific order:\nadding resource-preservation annotations to the stored release\nmanifests, uninstalling the legacy releases without running cleanup\nhooks, then installing the unified chart so it adopts the existing\nresources. The ordering matters because annotations must be in the\nstored manifest (not just on live objects) for Helm to honor them,\nhooks must be skipped or they delete PolicyServers, and both the\nrelease name and the chart&#39;s `nameOverride` must match the legacy ones\n(see the \&#34;Chart rename / resource naming\&#34; caveat) or Kubernetes\nrejects the update due to immutable selectors. Getting any step wrong\ncan delete resources or break admission, so the script handles it all\nand verifies each step.\n\nWhat survives the migration:\n\n- The five Kubewarden CRDs.\n- Your custom `PolicyServer` instances and policy CRs, along with\n  their `Validating`/`MutatingWebhookConfiguration` objects.\n- The `default` `PolicyServer` and recommended policy CRs (if\n  enabled). The unified chart&#39;s DefaultsApplier adopts them in\n  place. The `policy-server-default` Deployment is owned by the\n  `PolicyServer` CR through an owner reference, so as long as the\n  CR survives, the Deployment stays up and admission continues.\n- The `kubewarden-ca` Secret. Already-running policy-server pods\n  stay trusted by the new webhook CA bundles. No TLS rotation\n  happens.\n\nTo facilitate the migration process the Kubewarden team provided a script that\nperform all the required operation to allow a migration to the unified Helm\nchart with no downtime. To be able to use the script users must be aware of the\nprerequisites listed below.\n\nIf for some reason some of the prerequisites is not possible user should backup\nall the resources they currently have which is the policy servers and policies\nand reinstall them after the reinstallation of the stack. This means that the\nmigration will cause down time in the policy evaluation.\n\n&gt; [!WARNING]\n&gt; The Kubewarden team test the migration path as much as possible. But it is\n&gt; still recommended to backup policies and policy server definitions just in\n&gt; case something unexpected happens. Therefore, it will be easier to restore to\n&gt; the previous state if necessary.\n\n### Prerequisites\n\n- Helm v4+ (needed for Server-Side Apply and post-renderer plugins)\n- kubectl with access to your cluster\n- yq v4 (github.com/mikefarah/yq) for the post-renderer\n- jq for detecting installed chart versions\n- The three legacy releases must be installed in your cluster\n\nThe script runs five phases:\n\n1. Preflight: checks that the required tools are available, connects\n   to the cluster, finds the three legacy releases, and warns if\n   they are not at the latest chart version.\n2. Annotation injection: creates a Helm 4 post-renderer plugin that\n   wraps `yq`, then runs `helm upgrade --reuse-values --post-renderer`\n   on each legacy release to write `helm.sh/resource-policy: keep`\n   into the stored release manifests.\n3. Legacy uninstall: runs `helm uninstall --no-hooks` in reverse\n   order. The `--no-hooks` flag skips the controller chart&#39;s\n   pre-delete hook, which would otherwise delete all PolicyServers.\n   Resources stay live in the cluster.\n4. Unified chart install: runs `helm install --take-ownership`.\n   Helm 4&#39;s Server-Side Apply adopts existing resources, updates\n   their ownership metadata, and removes the legacy keep annotations\n   from chart-rendered resources.\n5. Verification: checks that CRDs are owned by the new release,\n   RBAC resources were adopted in place (UIDs did not change), the\n   controller pod is running, and the DefaultsApplier has labeled\n   the default PolicyServer and recommended policies.\n\n### Running the migration\n\n```sh\n./kubewarden-unified-adm-controller-chart-migration.sh \\\n  --unified-chart kubewarden/admission-controller\n```\n\nUsing a local tarball:\n\n```sh\n./kubewarden-unified-adm-controller-chart-migration.sh \\\n  --unified-chart ./admission-controller-6.0.0.tgz\n```\n\nDry run (no changes applied):\n\n```sh\n./kubewarden-unified-adm-controller-chart-migration.sh \\\n  --unified-chart kubewarden/admission-controller --dry-run\n```\n\nInteractive mode (pauses before each destructive step):\n\n```sh\n./kubewarden-unified-adm-controller-chart-migration.sh \\\n  --unified-chart kubewarden/admission-controller --interactive\n```\n\nPassing custom values to the unified chart:\n\n```sh\n./kubewarden-unified-adm-controller-chart-migration.sh \\\n  --unified-chart kubewarden/admission-controller \\\n  --set \&#34;image.tag=v2.0.0\&#34; \\\n  --values ./my-custom-values.yaml\n```\n\n#### Available flags\n\n| Flag                           | Description                                                      |\n| ------------------------------ | ---------------------------------------------------------------- |\n| `--unified-chart PATH_OR_NAME` | Required. Local tarball or Helm repo chart name                  |\n| `--namespace NS`               | Namespace of the Kubewarden installation (default: `kubewarden`) |\n| `--kube-context CTX`           | Kubernetes context to use (default: current context)             |\n| `--repo-name NAME`             | Helm repo name (default: `kubewarden`)                           |\n| `--repo-url URL`               | Helm repo URL (default: `https://charts.kubewarden.io`)          |\n| `--timeout DURATION`           | Timeout for Helm operations (default: `5m`)                      |\n| `--set KEY=VALUE`              | Set a value for the unified chart install (repeatable)           |\n| `--values FILE` / `-f FILE`    | Values file for the unified chart install (repeatable)           |\n| `--interactive`                | Pause for confirmation before destructive steps                  |\n| `--dry-run`                    | Show what would be done without making changes                   |\n| `--help`                       | Print usage information                                          |\n\n### Caveats\n\n**Release name.** The unified chart must be installed with the same\nrelease name as the legacy `kubewarden-controller` release (usually\n`kubewarden-controller`). Kubernetes Deployments have an immutable\n`spec.selector.matchLabels` that includes\n`app.kubernetes.io/instance: &lt;release-name&gt;`. If the name does not\nmatch, the install fails with an immutable-field error. The script\ndetects the legacy release name automatically.\n\n**Chart rename / resource naming.** This chart is named\n`admission-controller`, so a fresh install names its resources after it\n(`app.kubernetes.io/name: admission-controller`, Deployment\n`&lt;release&gt;-admission-controller`). The legacy resources being adopted were\ncreated by the old `kubewarden-controller` chart and carry\n`app.kubernetes.io/name: kubewarden-controller` in the same immutable\nselector. The migration script builds a values file by concatenating\n`helm get values` from the three legacy releases (`kubewarden-crds`,\n`kubewarden-controller`, `kubewarden-defaults`) and writes a reconciled\n`nameOverride` into it (filled with `kubewarden-controller` only when\nyou had not set it) so the chart reproduces the old names/labels and\nServer-Side Apply adopts the objects in place. Any `--set`/`--values`\nyou pass to the script override the merged values. These values are\nstored in the release, so **future upgrades must keep them** — run\n`helm upgrade ... --reuse-values`, or pass the generated\n`kw-merged-values.yaml` with `--values`. Dropping `nameOverride`\nre-renders `admission-controller`-named selectors and fails on the immutable\nfield. (A cluster migrated this way keeps `kubewarden-controller`\nresource names; a brand-new install uses `admission-controller`.)\n\n**Controller gap.** Between the legacy uninstall and the unified\nchart becoming ready, no controller is running. Existing webhook\nconfigurations are still served by the surviving policy-server pods,\nso admission for active policies keeps working. New policy CRs\ncreated during this window are not reconciled into webhooks until\nthe new controller starts.\n\n**Legacy defaults not carried over.** The migration script uses\n`helm get values` (user-supplied overrides only, not `--all`) to build\nthe merged values file. Settings that were only legacy chart\n_defaults_ (never explicitly set by you) are not carried over. If you\nrelied on them, pass them with `--set` or `--values`. Notably, the\nunified chart defaults are `recommendedPolicies.enabled: false` and\n`recommendedPolicies.defaultPolicyMode: \&#34;monitor\&#34;` (the script no\nlonger forces `enabled=true` / `protect`). If the legacy defaults chart\nenabled recommended policies by default and you never overrode that,\npass `--set recommendedPolicies.enabled=true` and\n`--set recommendedPolicies.defaultPolicyMode=protect` to keep them.\n\n**Settings drift.** The DefaultsApplier rewrites each recommended\npolicy&#39;s spec to match the values you pass to the unified chart. If\nyou had changed `mode`, `settings`, or other fields on the\nrecommended policies, pass those same values with `--set` or\n`--values` to preserve your configuration.\n\n**Renamed policies.** The unified chart&#39;s default policy names match\nthe legacy defaults. If you renamed any through legacy values, pass\nthe same `name` overrides with `--set` or `--values`. Otherwise the\napplier removes the old-named CRs after install.\n\n**Custom RBAC.** If you added extra permissions to\n`kubewarden-context-watcher` by hand, the unified chart overwrites\nthem on install. Include those permissions in a values file or pass\nthem with `--set \&#34;policyServer.permissions[0].apiGroup=...\&#34;`.\n\n## Configuration\n\n### Defaults\n\nThe chart can deploy a default Policy Server and recommended policies:\n\n```yaml\npolicyServer:\n  enabled: true\n  replicaCount: 1\n  # ... (see values.yaml for full options)\n\nrecommendedPolicies:\n  enabled: false # disabled by default\n  defaultPolicyMode: \&#34;monitor\&#34;\n  allowPrivilegeEscalationPolicy:\n    # ... (see values.yaml)\n```\n\nThese resources are owned and reconciled by the controller. Manual\nchanges are reverted on the next reconciliation. Setting `enabled`\nto `false` removes all managed resources.\n\n### CRDs\n\nCRDs are installed with the `helm.sh/resource-policy: keep` annotation:\n\n- `helm upgrade` updates CRDs normally\n- `helm uninstall` does not delete CRDs, which prevents cascade-deletion of all PolicyServers and policies in the cluster\n\n#### Reinstalling under a different release name or namespace\n\nBecause the CRDs are kept on uninstall, they survive with the Helm\nownership metadata of the release that created them\n(`meta.helm.sh/release-name` and `meta.helm.sh/release-namespace`). Helm\nchecks this metadata on the next install:\n\n- Same release name **and** namespace: Helm adopts the existing CRDs and\n  the install succeeds.\n- Different release name **or** namespace: Helm refuses to take over the\n  CRDs and the install fails with:\n\n  ```\n  Error: ... invalid ownership metadata; annotation\n  meta.helm.sh/release-name must equal \&#34;&lt;new&gt;\&#34;: current value is \&#34;&lt;old&gt;\&#34;\n  ```\n\nThis is expected: the CRDs still belong to the previous release. To adopt\nthem into the new release, install with `--take-ownership` (Helm 3.18+ or\nHelm 4), which re-stamps the ownership metadata:\n\n```sh\nhelm install &lt;release&gt; &lt;chart&gt; -n &lt;namespace&gt; --take-ownership\n```\n\n## Uninstall\n\n```sh\nhelm uninstall kubewarden-controller -n kubewarden\n```\n\nThis removes:\n\n- The controller Deployment\n- Managed defaults (resources labeled `kubewarden.io/managed-by=kubewarden-controller-defaults`)\n- ConfigMaps, Secrets, Services\n\nIt does not remove:\n\n- CRDs (kept by `helm.sh/resource-policy: keep`)\n- User-managed PolicyServers and policies\n\nTo remove CRDs after uninstall:\n\n```sh\nkubectl delete crd policyservers.policies.kubewarden.io\nkubectl delete crd clusteradmissionpolicies.policies.kubewarden.io\nkubectl delete crd admissionpolicies.policies.kubewarden.io\nkubectl delete crd clusteradmissionpolicygroups.policies.kubewarden.io\nkubectl delete crd admissionpolicygroups.policies.kubewarden.io\n```\n\n# Software bill of materials &amp; provenance\n\nAll Kubewarden components has its software bill of materials (SBOM) and build\n[Provenance](https://slsa.dev/spec/v1.0/provenance) information published every\nrelease. It follows the [SPDX](https://spdx.dev/) format and\n[SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema.\nBoth of the files are generated by [Docker\nbuildx](https://docs.docker.com/build/metadata/attestations/) during the build\nprocess and stored in the container registry together with the container image\nas well as upload in the release page.\n\nYou can find them together with the signature and certificate used to sign it\nin the [release\nassets](https://github.com/kubewarden/adm-controller/releases), and\nattached to the image as JSON-encoded documents following the [in-toto SPDX\npredicate](https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md)\nformat. You can obtain them with\n[`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)\nor [`docker buildx imagetools\ninspect`](https://docs.docker.com/reference/cli/docker/buildx/imagetools/inspect).\n\nYou can verify the container image with:\n\n```shell\ncosign verify-blob --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \\\n    --certificate-identity=\&#34;https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@&lt;TAG TO VERIFY&gt;\&#34; \\\n    --bundle controller-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore \\\n    controller-attestation-amd64-provenance.intoto.jsonl\n```\n\nTo verify the attestation manifest and its layer signatures:\n\n```shell\ncosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \\\n    --certificate-identity=\&#34;https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@&lt;TAG TO VERIFY&gt;\&#34; \\\n    ghcr.io/kubewarden/adm-controller/controller@sha256:1abc0944378d9f3ee2963123fe84d045248d320d76325f4c2d4eb201304d4c4e\n```\n\n&gt; [!NOTE]\n&gt; All the commands and file locations used in this section to validate the\n&gt; controller components can be used to verify all the others Kubewarden\n&gt; components as well.\n\nThat sha256 hash is the digest of the attestation manifest or its layers.\nTherefore, you need to find this hash in the registry using the UI or tools\nlike `crane`. For example, the following command will show you all the\nattestation manifests of the `latest` tag:\n\n```shell\ncrane manifest  ghcr.io/kubewarden/adm-controller/controller:latest | jq &#39;.manifests[] | select(.annotations[\&#34;vnd.docker.reference.type\&#34;]==\&#34;attestation-manifest\&#34;)&#39;\n{\n  \&#34;mediaType\&#34;: \&#34;application/vnd.oci.image.manifest.v1+json\&#34;,\n  \&#34;digest\&#34;: \&#34;sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8\&#34;,\n  \&#34;size\&#34;: 1655,\n  \&#34;annotations\&#34;: {\n    \&#34;vnd.docker.reference.digest\&#34;: \&#34;sha256:611d499ec9a26034463f09fa4af4efe2856086252d233b38e3fc31b0b982d369\&#34;,\n    \&#34;vnd.docker.reference.type\&#34;: \&#34;attestation-manifest\&#34;\n  },\n  \&#34;platform\&#34;: {\n    \&#34;architecture\&#34;: \&#34;unknown\&#34;,\n    \&#34;os\&#34;: \&#34;unknown\&#34;\n  }\n}\n{\n  \&#34;mediaType\&#34;: \&#34;application/vnd.oci.image.manifest.v1+json\&#34;,\n  \&#34;digest\&#34;: \&#34;sha256:e0cd736c2241407114256e09a4cdeef55eb81dcd374c5785c4e5c9362a0088a2\&#34;,\n  \&#34;size\&#34;: 1655,\n  \&#34;annotations\&#34;: {\n    \&#34;vnd.docker.reference.digest\&#34;: \&#34;sha256:03e5db83a25ea2ac498cf81226ab8db8eb53a74a2c9102e4a1da922d5f68b70f\&#34;,\n    \&#34;vnd.docker.reference.type\&#34;: \&#34;attestation-manifest\&#34;\n  },\n  \&#34;platform\&#34;: {\n    \&#34;architecture\&#34;: \&#34;unknown\&#34;,\n    \&#34;os\&#34;: \&#34;unknown\&#34;\n  }\n}\n```\n\nThen you can use the `digest` field to verify the attestation manifest and its\nlayers signatures.\n\n```shell\ncosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \\\n    --certificate-identity=\&#34;https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@&lt;TAG TO VERIFY&gt;\&#34; \\\n    ghcr.io/kubewarden/adm-controller/controller@sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8\n\ncrane manifest  ghcr.io/kubewarden/adm-controller/controller@sha256:fc01fa6c82cffeffd23b737c7e6b153357d1e499295818dad0c7d207f64e6ee8\n{\n  \&#34;schemaVersion\&#34;: 2,\n  \&#34;mediaType\&#34;: \&#34;application/vnd.oci.image.manifest.v1+json\&#34;,\n  \&#34;config\&#34;: {\n    \&#34;mediaType\&#34;: \&#34;application/vnd.oci.image.config.v1+json\&#34;,\n    \&#34;digest\&#34;: \&#34;sha256:eda788a0e94041a443eca7286a9ef7fce40aa2832263f7d76c597186f5887f6a\&#34;,\n    \&#34;size\&#34;: 463\n  },\n  \&#34;layers\&#34;: [\n    {\n      \&#34;mediaType\&#34;: \&#34;application/vnd.in-toto+json\&#34;,\n      \&#34;digest\&#34;: \&#34;sha256:563689cdee407ab514d057fe2f8f693189279e10bfe4f31f277e24dee00793ea\&#34;,\n      \&#34;size\&#34;: 94849,\n      \&#34;annotations\&#34;: {\n        \&#34;in-toto.io/predicate-type\&#34;: \&#34;https://spdx.dev/Document\&#34;\n      }\n    },\n    {\n      \&#34;mediaType\&#34;: \&#34;application/vnd.in-toto+json\&#34;,\n      \&#34;digest\&#34;: \&#34;sha256:7ce0572628290373e17ba0bbb44a9ec3c94ba36034124931d322ca3fbfb768d9\&#34;,\n      \&#34;size\&#34;: 7363045,\n      \&#34;annotations\&#34;: {\n        \&#34;in-toto.io/predicate-type\&#34;: \&#34;https://spdx.dev/Document\&#34;\n      }\n    },\n    {\n      \&#34;mediaType\&#34;: \&#34;application/vnd.in-toto+json\&#34;,\n      \&#34;digest\&#34;: \&#34;sha256:dacf511c5ec7fd87e8692bd08c3ced2c46f4da72e7271b82f1b3720d5b0a8877\&#34;,\n      \&#34;size\&#34;: 71331,\n      \&#34;annotations\&#34;: {\n        \&#34;in-toto.io/predicate-type\&#34;: \&#34;https://spdx.dev/Document\&#34;\n      }\n    },\n    {\n      \&#34;mediaType\&#34;: \&#34;application/vnd.in-toto+json\&#34;,\n      \&#34;digest\&#34;: \&#34;sha256:594da3e8bd8c6ee2682b0db35857933f9558fd98ec092344a6c1e31398082f4d\&#34;,\n      \&#34;size\&#34;: 980,\n      \&#34;annotations\&#34;: {\n        \&#34;in-toto.io/predicate-type\&#34;: \&#34;https://spdx.dev/Document\&#34;\n      }\n    },\n    {\n      \&#34;mediaType\&#34;: \&#34;application/vnd.in-toto+json\&#34;,\n      \&#34;digest\&#34;: \&#34;sha256:7738d8d506c6482aaaef1d22ed920468ffaf4975afd28f49bb50dba2c20bf2ca\&#34;,\n      \&#34;size\&#34;: 13838,\n      \&#34;annotations\&#34;: {\n        \&#34;in-toto.io/predicate-type\&#34;: \&#34;https://slsa.dev/provenance/v0.2\&#34;\n      }\n    }\n  ]\n}\n\ncosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com  \\\n    --certificate-identity=\&#34;https://github.com/kubewarden/adm-controller/.github/workflows/attestation.yml@&lt;TAG TO VERIFY&gt;\&#34; \\\n    ghcr.io/kubewarden/adm-controller/controller@sha256:594da3e8bd8c6ee2682b0db35857933f9558fd98ec092344a6c1e31398082f4d\n```\n\nNote that each attestation manifest (for each architecture) has its own layers.\nEach layer is a different SBOM SPDX or provenance file generated by Docker\nBuildx during the multi stage build process. You can also use `crane` to\ndownload the attestation file:\n\n```shell\ncrane blob ghcr.io/kubewarden/adm-controller/controller@sha256:7738d8d506c6482aaaef1d22ed920468ffaf4975afd28f49bb50dba2c20bf2ca\n```\n\n## Security disclosure\n\nSee [SECURITY.md](https://github.com/kubewarden/community/blob/main/SECURITY.md) on the kubewarden/community repo.\n\n# Changelog\n\nSee [GitHub Releases content](https://github.com/kubewarden/adm-controller/releases).\n&#34;:&#xA;&#xA;* charts/admission-controller/README.md&#xA;</p>
        </details>
        <details id="7919632787490fc01ed098f23d120795a7ac09d568c6534835e0daef25dbcf0a">
            <summary>Update Helm chart admission-controller appVersion</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.appVersion&#34; updated from &#34;v1.37.0-alpha.1&#34; to &#34;v1.37.0-alpha&#34;, in file &#34;charts/admission-controller/Chart.yaml&#34;</p>
        </details>
        <details id="8c56b8050c3dccdc8d47e352f502d55aa3f9eadbfa54b3fe0b8aaa89bbe48be9">
            <summary>Update Helm chart admission-controller image tag</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.image.tag&#34; updated from &#34;v1.36.0&#34; to &#34;v1.37.0-alpha&#34;, in file &#34;charts/admission-controller/values.yaml&#34;</p>
        </details>
        <details id="8f801271979ad348297d15b3c1f7112ced02c274c66e86df0dac769c8cc6c20d">
            <summary>Update Helm chart policy-server version</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.policyServer.image.tag&#34; updated from &#34;v1.36.0&#34; to &#34;v1.37.0-alpha&#34;, in file &#34;charts/admission-controller/values.yaml&#34;</p>
        </details>
        <details id="91340d1b2414c6c4ab7f332790b76de72b4a7fd34ce31179e9cafedd7aa92903">
            <summary>Update admission-controller Helm chart version in Hauler manifest</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.spec.charts[0].version&#34; updated from &#34;6.0.0-alpha.1&#34; to &#34;6.1.0&#34;, in file &#34;charts/hauler_manifest.yaml&#34;</p>
        </details>
        <details id="eef42bf41951f6f34e574585c10204c08f0084abbec665dfd16409c01b12eafe">
            <summary>Update Helm chart audit-scanner version</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.auditScanner.image.tag&#34; updated from &#34;v1.36.0&#34; to &#34;v1.37.0-alpha&#34;, in file &#34;charts/admission-controller/values.yaml&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

